### PR TITLE
Fixed test for stdout in non-tty use case of repo fork

### DIFF
--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -390,6 +390,7 @@ func TestRepoFork(t *testing.T) {
 				},
 			},
 			httpStubs: forkPost,
+			wantOut:   "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "implicit nontty remote exists",
@@ -424,11 +425,13 @@ func TestRepoFork(t *testing.T) {
 				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
 			},
+			wantOut: "https://github.com/someone/REPO\n",
 		},
 		{
 			name:      "implicit nontty no args",
 			opts:      &ForkOptions{},
 			httpStubs: forkPost,
+			wantOut:   "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "passes git flags",
@@ -561,6 +564,7 @@ func TestRepoFork(t *testing.T) {
 				Repository: "OWNER/REPO",
 			},
 			httpStubs: forkPost,
+			wantOut:   "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "repo arg nontty repo already exists",
@@ -604,6 +608,7 @@ func TestRepoFork(t *testing.T) {
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
 			},
+			wantOut: "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "non tty repo arg with fork-name",
@@ -640,6 +645,7 @@ func TestRepoFork(t *testing.T) {
 					httpmock.StringResponse(renameResult))
 			},
 			wantErrOut: "",
+			wantOut:    "https://github.com/OWNER/REPO\n",
 		},
 		{
 			name: "tty repo arg with fork-name",
@@ -694,6 +700,7 @@ func TestRepoFork(t *testing.T) {
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
 			},
+			wantOut: "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "does not retry clone if error occurs and exit code is not 128",


### PR DESCRIPTION
## Explanation

So in order to understand which tests to fix, I ran them locally from the `pkg/cmd/repo/fork` directory:

```sh
$ cd pkg/cmd/repo/fork
$ go test
```

I could have run all the tests from the root directory using `go test ./...`, but that would've been a waste of time given the impact of this change.

The output of this resulted in a bunch of failed tests like this:

```sh
--- FAIL: TestRepoFork (0.04s)
    --- FAIL: TestRepoFork/implicit_nontty_reuse_existing_remote (0.00s)
        fork_test.go:789: 
                Error Trace:    /Users/jtmcg/projects/cli/cli/pkg/cmd/repo/fork/fork_test.go:789
                Error:          Not equal: 
                                expected: ""
                                actual  : "https://github.com/someone/REPO\n"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1,2 @@
                                +https://github.com/someone/REPO
                                 
                Test:           TestRepoFork/implicit_nontty_reuse_existing_remote
```

You can find the test in the file by the name: `TestRepoFork/implicit_nontty_reuse_existing_remote`. This one in particular is [here](https://github.com/cli/cli/blob/d6dba9358666a9d8beee4b98de3e61ea06b4e554/pkg/cmd/repo/fork/fork_test.go#L376-L393).

What this is telling me is that we're outputing the URL (which we want 👍 ) but the test isn't expecting that output. In order to specify it, our [table tests' stuct](https://github.com/cli/cli/blob/d6dba9358666a9d8beee4b98de3e61ea06b4e554/pkg/cmd/repo/fork/fork_test.go#L208C2-L221) in this block of code use a [`wantOut` string](https://github.com/cli/cli/blob/d6dba9358666a9d8beee4b98de3e61ea06b4e554/pkg/cmd/repo/fork/fork_test.go#L217).

In all of these test cases, I just copy/pasted the "actual" output from the tests to the `wantOut` string. I usually wouldn't do this, as this could easily result in testing unintentional behavior. For example, if the code here had a bug, I wouldn't catch it with the test by copy/pasting things. I often find it better to write/update tests for these types of things before writing the code for it to avoid that kind of circular logic. However, this is a simple enough change that I'm not particularly worried about that 🙂 

Anyway, you should just be able to merge this PR into your branch, then we should pass our test coverage and be able to merge your PR 🥳 

Let me know if you have any questions about this and I'm happy to answer them